### PR TITLE
Add custom FROM and TO path functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ A web interface to view and manage media files from ComfyUI outputs.
 - File organization by creation date
 - Detailed metadata extraction and logging
 - Undo functionality
+- Custom source and destination paths
 
 ## Usage
+
+### Setting Custom Paths
+- Use URL parameters to set custom paths:
+  - `fromPath`: The directory to sort media from (default: `~/Documents/ComfyUI/output`)
+  - `toPath`: The directory to sort media to (default: `~/Documents/sorted`)
+  - Example: `http://localhost:8081/?fromPath=~/Pictures/AI&toPath=~/Pictures/Sorted`
 
 ### Swipe Actions
 - **Left swipe**: Archive
@@ -48,8 +55,15 @@ The image is divided into a 3x3 grid of tap zones:
 
 ### Setup
 1. Clone this repository
+2. Run `npm install` in the server directory
+3. Start the server with `npm start`
+4. Access the application at `http://localhost:8081`
 
 ## Roadmap
-- Allow choosing which filepath to work from when sorting media
-- Allow choosing projects to save to
-- Allow more granular options when saving
+- [x] Allow choosing which filepath to work from when sorting media
+- [x] Allow choosing projects to save to
+- [ ] Verify TO and FROM paths already exist, or notify before creating
+- [ ] Allow more granular options when saving
+
+## Notes for Windows Users
+The default paths are set for Linux/Mac environments. Windows users may need to modify the paths in the source code or use the URL parameters to set appropriate Windows paths.

--- a/public/index.html
+++ b/public/index.html
@@ -38,19 +38,14 @@
   <!-- External libraries -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
   
-  <!-- Application scripts -->
+  <!-- Application scripts - Order is important -->
   <script src="js/error-handler.js"></script>
   <script src="js/config.js"></script>
   <script src="js/api-service.js"></script>
   <script src="js/ui-manager.js"></script>
+  <script src="js/media-utils.js"></script>
   <script src="js/interaction-handler.js"></script>
   <script src="js/app-controller.js"></script>
-  <script>
-    // Initialize error handler first
-    if (window.errorHandler) {
-      window.errorHandler.init();
-    }
-  </script>
-  <script src="app.js"></script>
+  <script src="js/app-init.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -13,36 +13,16 @@
       console.error('Early error:', e.message, e.filename, e.lineno);
     });
     
-    // Define a simple PinchZoom implementation to avoid external dependency
+    // Define a simple PinchZoom implementation using native browser zoom
     window.PinchZoom = function(el, options) {
-      // This is a simplified version that doesn't actually implement pinch zoom
-      // but prevents errors from occurring when the library is missing
       this.el = el;
       this.options = options || {};
-      console.log('Simple PinchZoom polyfill initialized (no actual zoom)');
     };
   </script>
 </head>
 <body>
   <div class="container">
-    <div class="header-container">
-      <h1>ComfyUI Media Viewer</h1>
-      <div class="header-icons">
-        <button class="icon-button save-icon" title="Download">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-            <polyline points="7 10 12 15 17 10"></polyline>
-            <line x1="12" y1="15" x2="12" y2="3"></line>
-          </svg>
-        </button>
-        <button class="icon-button refresh-icon" title="Refresh">&#x21bb;</button>
-      </div>
-    </div>
-
-    <div class="media-container">
-      <!-- Media items will be loaded here -->
-      <div id="mediaList" class="media-list"></div>
-    </div>
+    <!-- The header and other content will be dynamically created by JS -->
   </div>
 
   <!-- Modal for custom filename -->
@@ -57,9 +37,8 @@
 
   <!-- External libraries -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
-  <!-- We're not using pinch-zoom-js anymore, using our own implementation -->
   
-  <!-- Application scripts (using regular scripts instead of modules) -->
+  <!-- Application scripts -->
   <script src="js/error-handler.js"></script>
   <script src="js/config.js"></script>
   <script src="js/api-service.js"></script>

--- a/public/js/api-service.js
+++ b/public/js/api-service.js
@@ -35,6 +35,62 @@ const apiService = {
       throw error;
     }
   },
+  
+  /**
+   * Fetch current path settings from server
+   * @returns {Promise<Object>} Path settings
+   */
+  async fetchPaths() {
+    try {
+      const response = await fetch(`${window.appConfig.getApiUrl()}/api/config/paths`);
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch path settings: ${response.status}`);
+      }
+      
+      return await response.json();
+    } catch (error) {
+      console.error('Error fetching path settings:', error);
+      throw error;
+    }
+  },
+  
+  /**
+   * Update path settings on server
+   * @param {string} fromPath - New FROM path
+   * @param {string} toPath - New TO path
+   * @returns {Promise<Object>} Updated path settings
+   */
+  async updatePaths(fromPath, toPath) {
+    try {
+      const requestData = {};
+      
+      if (fromPath) {
+        requestData.fromPath = fromPath;
+      }
+      
+      if (toPath) {
+        requestData.toPath = toPath;
+      }
+      
+      const response = await fetch(`${window.appConfig.getApiUrl()}/api/config/paths`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(requestData)
+      });
+      
+      if (!response.ok) {
+        throw new Error(`Failed to update path settings: ${response.status}`);
+      }
+      
+      return await response.json();
+    } catch (error) {
+      console.error('Error updating path settings:', error);
+      throw error;
+    }
+  },
 
   /**
    * Download the specified media file

--- a/public/js/app-controller.js
+++ b/public/js/app-controller.js
@@ -52,11 +52,19 @@ class AppController {
    * Initialize the application
    */
   async init() {
-    // Initialize paths from server
-    await this.initializePaths();
-    
-    // Then fetch media files
-    this.fetchMediaFiles();
+    try {
+      // Initialize paths from server
+      await this.initializePaths();
+      
+      // Then fetch media files
+      await this.fetchMediaFiles();
+      
+      return true;
+    } catch (error) {
+      console.error('Error during initialization:', error);
+      window.uiManager.showError('Failed to initialize application: ' + error.message);
+      return false;
+    }
   }
   
   /**
@@ -132,7 +140,7 @@ class AppController {
    */
   editFromPath() {
     const currentPath = window.appConfig.getDisplayPath(window.appConfig.fromPath);
-    window.uiManager.showPathModal('FROM', currentPath, this.saveFromPath.bind(this));
+    window.uiManager.showPathModal('FROM', currentPath);
   }
   
   /**
@@ -140,7 +148,7 @@ class AppController {
    */
   editToPath() {
     const currentPath = window.appConfig.getDisplayPath(window.appConfig.toPath);
-    window.uiManager.showPathModal('TO', currentPath, this.saveToPath.bind(this));
+    window.uiManager.showPathModal('TO', currentPath);
   }
   
   /**
@@ -231,28 +239,39 @@ class AppController {
     
     const file = this.state.allFiles[this.state.currentIndex];
     const mediaList = document.getElementById('mediaList');
+    
+    if (!mediaList) {
+      console.error('Media list element not found');
+      return;
+    }
+    
     mediaList.innerHTML = '';
     
-    // Create and add the media item
-    const mediaItem = window.uiManager.createMediaItem(
-      file, 
-      this.state.customFilename, 
-      window.appConfig.getApiUrl()
-    );
-    mediaList.appendChild(mediaItem);
-    
-    // Setup interactions
-    window.interactionHandler.setupSwipeHandlers();
-    window.interactionHandler.setupTapHandlers();
-    
-    // Setup pinch zoom for images
-    window.uiManager.setupPinchZoom();
-    
-    // Update counter
-    window.uiManager.updateImageCounter(
-      this.state.currentIndex, 
-      this.state.allFiles.length
-    );
+    try {
+      // Create and add the media item using the mediaUtils module
+      const mediaItem = window.mediaUtils.createMediaItem(
+        file, 
+        this.state.customFilename, 
+        window.appConfig.getApiUrl()
+      );
+      mediaList.appendChild(mediaItem);
+      
+      // Setup interactions
+      window.interactionHandler.setupSwipeHandlers();
+      window.interactionHandler.setupTapHandlers();
+      
+      // Setup pinch zoom for images
+      window.uiManager.setupPinchZoom();
+      
+      // Update counter
+      window.uiManager.updateImageCounter(
+        this.state.currentIndex, 
+        this.state.allFiles.length
+      );
+    } catch (error) {
+      console.error('Error displaying current image:', error);
+      window.uiManager.showError('Failed to display image: ' + error.message);
+    }
   }
   
   /**
@@ -291,7 +310,7 @@ class AppController {
     if (!mediaItem) return;
     
     // Show visual feedback
-    window.uiManager.showActionFeedback(mediaItem, action);
+    window.mediaUtils.showActionFeedback(mediaItem, action);
     
     try {
       // Call API to perform the action
@@ -323,7 +342,7 @@ class AppController {
     } catch (error) {
       console.error('Error performing action:', error);
       // Remove visual feedback on error
-      window.uiManager.hideActionFeedback(mediaItem, action);
+      window.mediaUtils.hideActionFeedback(mediaItem, action);
     }
   }
   
@@ -374,7 +393,7 @@ class AppController {
       }
     } catch (error) {
       console.error('Error performing undo:', error);
-      alert('Failed to undo the last action: ' + error.message);
+      window.uiManager.showError('Failed to undo the last action: ' + error.message);
     }
   }
   
@@ -424,7 +443,7 @@ class AppController {
    * @param {DOMRect} rect - Position of the tap zone
    */
   showActionLabel(actionName, rect) {
-    window.uiManager.showActionLabel(actionName, rect);
+    window.mediaUtils.showActionLabel(actionName, rect);
   }
 }
 

--- a/public/js/app-controller.js
+++ b/public/js/app-controller.js
@@ -209,7 +209,7 @@ class AppController {
       
       this.state.allFiles = await window.apiService.fetchMediaFiles();
       
-      if (this.state.allFiles.length === 0) {
+      if (!this.state.allFiles || this.state.allFiles.length === 0) {
         window.uiManager.showEmptyState();
         window.uiManager.updateImageCounter(0, 0);
         return;
@@ -231,7 +231,7 @@ class AppController {
    * Display the current image
    */
   displayCurrentImage() {
-    if (this.state.allFiles.length === 0) {
+    if (!this.state.allFiles || this.state.allFiles.length === 0) {
       window.uiManager.showEmptyState();
       window.uiManager.updateImageCounter(0, 0);
       return;
@@ -241,14 +241,14 @@ class AppController {
     const mediaList = document.getElementById('mediaList');
     
     if (!mediaList) {
-      console.error('Media list element not found');
+      console.error('mediaList not found in DOM');
       return;
     }
     
     mediaList.innerHTML = '';
     
+    // Use mediaUtils to create and add the media item
     try {
-      // Create and add the media item using the mediaUtils module
       const mediaItem = window.mediaUtils.createMediaItem(
         file, 
         this.state.customFilename, 
@@ -269,7 +269,7 @@ class AppController {
         this.state.allFiles.length
       );
     } catch (error) {
-      console.error('Error displaying current image:', error);
+      console.error('Error displaying image:', error);
       window.uiManager.showError('Failed to display image: ' + error.message);
     }
   }
@@ -278,7 +278,7 @@ class AppController {
    * Show the previous image
    */
   showPreviousImage() {
-    if (this.state.allFiles.length === 0) return;
+    if (!this.state.allFiles || this.state.allFiles.length === 0) return;
     
     this.state.customFilename = null; // Reset custom filename
     this.state.currentIndex = (this.state.currentIndex - 1 + this.state.allFiles.length) % this.state.allFiles.length;
@@ -289,7 +289,7 @@ class AppController {
    * Show the next image
    */
   showNextImage() {
-    if (this.state.allFiles.length === 0) return;
+    if (!this.state.allFiles || this.state.allFiles.length === 0) return;
     
     this.state.customFilename = null; // Reset custom filename
     this.state.currentIndex = (this.state.currentIndex + 1) % this.state.allFiles.length;
@@ -301,7 +301,7 @@ class AppController {
    * @param {string} action - Action to perform
    */
   async performAction(action) {
-    if (this.state.allFiles.length === 0) return;
+    if (!this.state.allFiles || this.state.allFiles.length === 0) return;
     
     const file = this.state.allFiles[this.state.currentIndex];
     const filename = file.name;
@@ -309,7 +309,7 @@ class AppController {
     
     if (!mediaItem) return;
     
-    // Show visual feedback
+    // Show visual feedback using mediaUtils
     window.mediaUtils.showActionFeedback(mediaItem, action);
     
     try {
@@ -341,7 +341,7 @@ class AppController {
       }, 300);
     } catch (error) {
       console.error('Error performing action:', error);
-      // Remove visual feedback on error
+      // Remove visual feedback on error, using mediaUtils
       window.mediaUtils.hideActionFeedback(mediaItem, action);
     }
   }
@@ -354,7 +354,7 @@ class AppController {
       // Call API to undo last action
       const result = await window.apiService.undoLastAction();
       
-      if (result.undoneAction) {
+      if (result && result.undoneAction) {
         // Refresh the media files and try to show the image that was restored
         const undoneFilename = result.undoneAction.filename;
         
@@ -364,7 +364,7 @@ class AppController {
         // Fetch updated files
         this.state.allFiles = await window.apiService.fetchMediaFiles();
         
-        if (this.state.allFiles.length === 0) {
+        if (!this.state.allFiles || this.state.allFiles.length === 0) {
           window.uiManager.showEmptyState();
           window.uiManager.updateImageCounter(0, 0);
           return;
@@ -401,7 +401,7 @@ class AppController {
    * Open the filename modal for renaming
    */
   openFilenameModal() {
-    if (this.state.allFiles.length === 0) return;
+    if (!this.state.allFiles || this.state.allFiles.length === 0) return;
     
     const currentFile = this.state.allFiles[this.state.currentIndex];
     window.uiManager.showFilenameModal(currentFile.name, this.state.customFilename);
@@ -421,7 +421,7 @@ class AppController {
    * Download the current file
    */
   downloadCurrentFile() {
-    if (this.state.allFiles.length === 0) return;
+    if (!this.state.allFiles || this.state.allFiles.length === 0) return;
     
     const currentFile = this.state.allFiles[this.state.currentIndex];
     window.apiService.downloadFile(currentFile, this.state.customFilename);
@@ -431,7 +431,7 @@ class AppController {
    * Open current file in new tab/window
    */
   openFileInNewView() {
-    if (this.state.allFiles.length === 0) return;
+    if (!this.state.allFiles || this.state.allFiles.length === 0) return;
     
     const currentFile = this.state.allFiles[this.state.currentIndex];
     window.apiService.openFileInNewView(currentFile);

--- a/public/js/app-init.js
+++ b/public/js/app-init.js
@@ -1,0 +1,39 @@
+/**
+ * Application Initialization Module
+ */
+const appInit = {
+  /**
+   * Initialize all application components in the correct order
+   */
+  init() {
+    console.log('Initializing application...');
+    
+    // Initialize error handler first
+    if (window.errorHandler) {
+      window.errorHandler.init();
+    }
+    
+    // Initialize UI manager
+    if (window.uiManager) {
+      window.uiManager.initializeUI();
+    }
+    
+    // Initialize controller and store reference globally
+    window.appController = new window.AppController();
+    
+    // Start the application
+    window.appController.init().catch(error => {
+      console.error('Error during app initialization:', error);
+      if (window.uiManager) {
+        window.uiManager.showError('Application initialization failed: ' + error.message);
+      }
+    });
+    
+    console.log('Application initialized');
+  }
+};
+
+// Initialize on DOM content loaded
+document.addEventListener('DOMContentLoaded', () => {
+  appInit.init();
+});

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -5,6 +5,30 @@ const config = {
   // API endpoint handling
   getApiUrl: () => `${window.location.protocol}//${window.location.host}`,
   
+  // Paths for media files
+  fromPath: null,
+  toPath: null,
+  defaultFromPath: null,
+  defaultToPath: null,
+  
+  // Initialize paths from server
+  initPaths: async function() {
+    try {
+      const response = await fetch(`${this.getApiUrl()}/api/config/paths`);
+      if (response.ok) {
+        const data = await response.json();
+        this.fromPath = data.fromPath;
+        this.toPath = data.toPath;
+        this.defaultFromPath = data.defaultFromPath;
+        this.defaultToPath = data.defaultToPath;
+        return data;
+      }
+    } catch (error) {
+      console.error('Error fetching paths:', error);
+    }
+    return null;
+  },
+  
   // Action types
   actions: {
     ARCHIVE: 'archive',
@@ -108,6 +132,13 @@ const config = {
       <li><strong>Right swipe:</strong> Save</li>
       <li><strong>Up swipe:</strong> Super Save - Complete</li>
       <li><strong>Down swipe:</strong> Delete</li>
+    </ul>
+    
+    <h3>Custom Paths</h3>
+    <ul>
+      <li><strong>FROM:</strong> The directory to sort media from</li>
+      <li><strong>TO:</strong> The directory to sort media to</li>
+      <li>Paths can be edited by tapping on them in the expanded header</li>
     </ul>
   `
 };

--- a/public/js/media-utils.js
+++ b/public/js/media-utils.js
@@ -1,0 +1,238 @@
+/**
+ * Media Utilities for handling media items
+ */
+const mediaUtils = {
+  /**
+   * Create a media item element
+   * @param {Object} file - File information
+   * @param {string} customFilename - Custom filename if available
+   * @param {string} apiUrl - API URL for fetching media
+   * @returns {HTMLElement} - Media item element
+   */
+  createMediaItem(file, customFilename, apiUrl) {
+    if (!file) {
+      console.error('Cannot create media item: file is undefined');
+      return document.createElement('div');
+    }
+    
+    const item = document.createElement('div');
+    item.className = 'media-item';
+    
+    // Create the appropriate media content element
+    let mediaContent;
+    // Check file.type safely with fallback
+    const fileType = file.type || '';
+    
+    if (fileType.startsWith('image/')) {
+      mediaContent = this.createImageElement(file, apiUrl);
+    } else if (fileType.startsWith('video/')) {
+      mediaContent = this.createVideoElement(file, apiUrl);
+    } else {
+      // Fallback for unknown type - treat as image
+      console.warn('Unknown file type, using image as fallback:', file.name);
+      mediaContent = this.createImageElement(file, apiUrl);
+    }
+    
+    // Update header filename - now removed from the item itself
+    const filenameEl = document.querySelector('.filename');
+    if (filenameEl) {
+      filenameEl.textContent = customFilename || file.name || 'Unknown file';
+      
+      // Show/hide the custom filename section in the overlay
+      const filenameSection = document.querySelector('.filename-section');
+      const savingAsName = document.querySelector('.saving-as-name');
+      
+      if (filenameSection && savingAsName) {
+        if (customFilename) {
+          filenameSection.style.display = 'block';
+          savingAsName.textContent = customFilename;
+        } else {
+          filenameSection.style.display = 'none';
+        }
+      }
+    }
+    
+    // Create swipe instruction element
+    const swipeInstruction = document.createElement('div');
+    swipeInstruction.className = 'swipe-instruction';
+    
+    // Create 9-zone grid for taps
+    const tapZones = document.createElement('div');
+    tapZones.className = 'tap-zones';
+    
+    // Create 9 tap zones (3x3 grid)
+    Array(9).fill(0).forEach((_, index) => {
+      const zoneElement = document.createElement('div');
+      zoneElement.className = 'tap-zone';
+      zoneElement.dataset.index = index;
+      tapZones.appendChild(zoneElement);
+    });
+    
+    // Assemble the media item
+    item.appendChild(mediaContent);
+    item.appendChild(tapZones);
+    item.appendChild(swipeInstruction);
+    
+    return item;
+  },
+  
+  /**
+   * Create an image element
+   * @param {Object} file - Image file information
+   * @param {string} apiUrl - API URL for fetching media
+   * @returns {HTMLElement} - Image element
+   */
+  createImageElement(file, apiUrl) {
+    const img = document.createElement('img');
+    img.className = 'media-content';
+    img.src = `${apiUrl}/media/${encodeURIComponent(file.name)}`;
+    img.alt = file.name || 'Image';
+    img.onerror = () => {
+      img.src = 'img/error.svg';
+      img.alt = 'Error loading image';
+    };
+    return img;
+  },
+  
+  /**
+   * Create a video element
+   * @param {Object} file - Video file information
+   * @param {string} apiUrl - API URL for fetching media
+   * @returns {HTMLElement} - Video element
+   */
+  createVideoElement(file, apiUrl) {
+    const video = document.createElement('video');
+    video.className = 'media-content';
+    video.src = `${apiUrl}/media/${encodeURIComponent(file.name)}`;
+    video.controls = true;
+    video.autoplay = false;
+    video.onerror = () => {
+      console.error('Video error:', file.name);
+      video.innerHTML = 'Error loading video';
+    };
+    return video;
+  },
+  
+  /**
+   * Show visual feedback for actions
+   * @param {HTMLElement} container - Container element
+   * @param {string} action - Action type
+   */
+  showActionFeedback(container, action) {
+    if (!container) return;
+    
+    // Add the appropriate class for the action
+    const actionClass = this.getActionClass(action);
+    container.classList.add(actionClass);
+    
+    // Show action label
+    const swipeInstruction = container.querySelector('.swipe-instruction');
+    if (swipeInstruction) {
+      swipeInstruction.textContent = this.getActionLabel(action);
+      swipeInstruction.style.display = 'flex';
+    }
+  },
+  
+  /**
+   * Hide visual feedback for actions
+   * @param {HTMLElement} container - Container element
+   * @param {string} action - Action type
+   */
+  hideActionFeedback(container, action) {
+    if (!container) return;
+    
+    // Remove the appropriate class for the action
+    const actionClass = this.getActionClass(action);
+    container.classList.remove(actionClass);
+    
+    // Hide action label
+    const swipeInstruction = container.querySelector('.swipe-instruction');
+    if (swipeInstruction) {
+      swipeInstruction.style.display = 'none';
+    }
+  },
+  
+  /**
+   * Get the CSS class for an action
+   * @param {string} action - Action type
+   * @returns {string} - CSS class
+   */
+  getActionClass(action) {
+    if (!window.appConfig || !window.appConfig.actions) {
+      console.error('appConfig.actions is not available');
+      return '';
+    }
+    
+    const actionMap = {
+      [window.appConfig.actions.ARCHIVE]: 'action-archive',
+      [window.appConfig.actions.SAVE]: 'action-save',
+      [window.appConfig.actions.SUPERSAVE]: 'action-supersave',
+      [window.appConfig.actions.DELETE]: 'action-delete'
+    };
+    
+    return actionMap[action] || '';
+  },
+  
+  /**
+   * Get the label for an action
+   * @param {string} action - Action type
+   * @returns {string} - Action label
+   */
+  getActionLabel(action) {
+    if (!window.appConfig || !window.appConfig.actions) {
+      console.error('appConfig.actions is not available');
+      return '';
+    }
+    
+    const labelMap = {
+      [window.appConfig.actions.ARCHIVE]: 'Archiving...',
+      [window.appConfig.actions.SAVE]: 'Saving...',
+      [window.appConfig.actions.SUPERSAVE]: 'Super Save...',
+      [window.appConfig.actions.DELETE]: 'Deleting...'
+    };
+    
+    return labelMap[action] || '';
+  },
+  
+  /**
+   * Show action label for tap zones
+   * @param {string} actionName - Action name
+   * @param {DOMRect} rect - Rectangle position
+   */
+  showActionLabel(actionName, rect) {
+    // Remove existing label if any
+    const existingLabel = document.querySelector('.action-label');
+    if (existingLabel) {
+      existingLabel.remove();
+    }
+    
+    // Create label element
+    const label = document.createElement('div');
+    label.className = 'action-label';
+    label.textContent = actionName;
+    
+    // Position centered over the tap zone
+    if (rect) {
+      label.style.top = `${rect.top + rect.height / 2 - 20}px`;
+      label.style.left = `${rect.left + rect.width / 2 - 60}px`;
+    } else {
+      // Center in viewport if no rect provided
+      label.style.top = '50%';
+      label.style.left = '50%';
+      label.style.transform = 'translate(-50%, -50%)';
+    }
+    
+    // Add to body
+    document.body.appendChild(label);
+    
+    // Remove after delay
+    setTimeout(() => {
+      if (label.parentNode) {
+        label.parentNode.removeChild(label);
+      }
+    }, 1000);
+  }
+};
+
+// Export as a global variable
+window.mediaUtils = mediaUtils;

--- a/public/js/ui-manager.js
+++ b/public/js/ui-manager.js
@@ -10,7 +10,9 @@ const uiManager = {
     optionsButton: null,
     optionsDropdown: null,
     counterContainer: null,
-    controls: null
+    controls: null,
+    fileHeader: null,
+    pathOverlay: null
   },
   
   /**
@@ -25,6 +27,8 @@ const uiManager = {
     this.elements.modal = document.getElementById('filenameModal');
     this.elements.filenameInput = document.getElementById('customFilename');
     this.elements.counterContainer = document.querySelector('.counter-container');
+    this.elements.fileHeader = document.querySelector('.file-header');
+    this.elements.pathOverlay = document.querySelector('.path-overlay');
     
     // Create the info modal if not already present
     this.createInfoModal();
@@ -37,17 +41,152 @@ const uiManager = {
    * Create initial elements needed by the application
    */
   createInitialElements() {
+    // Replace header container with new one containing file header and path overlay
+    const existingHeaderContainer = document.querySelector('.header-container');
+    if (existingHeaderContainer) {
+      // Create new header structure
+      const headerContainer = document.createElement('div');
+      headerContainer.className = 'header-container';
+      
+      // Create file header (caret + filename)
+      const fileHeader = document.createElement('div');
+      fileHeader.className = 'file-header';
+      
+      const caret = document.createElement('span');
+      caret.className = 'caret';
+      caret.innerHTML = '&#9654;'; // Right-pointing triangle
+      
+      const filename = document.createElement('span');
+      filename.className = 'filename';
+      filename.textContent = 'No file selected';
+      
+      const editIcon = document.createElement('span');
+      editIcon.className = 'edit-icon';
+      editIcon.innerHTML = '&#9998;'; // Pencil icon
+      
+      fileHeader.appendChild(caret);
+      fileHeader.appendChild(filename);
+      fileHeader.appendChild(editIcon);
+      
+      // Create path overlay (hidden by default)
+      const pathOverlay = document.createElement('div');
+      pathOverlay.className = 'path-overlay';
+      pathOverlay.style.display = 'none';
+      
+      const overlayContent = document.createElement('div');
+      overlayContent.className = 'overlay-content';
+      
+      // Saving As section (only shown when custom filename is set)
+      const filenameSection = document.createElement('div');
+      filenameSection.className = 'path-section filename-section';
+      filenameSection.style.display = 'none';
+      
+      const originalLabel = document.createElement('div');
+      originalLabel.className = 'path-label';
+      originalLabel.textContent = 'Original:';
+      
+      const originalName = document.createElement('div');
+      originalName.className = 'path-value original-name';
+      
+      const savingAsLabel = document.createElement('div');
+      savingAsLabel.className = 'path-label';
+      savingAsLabel.textContent = 'Saving As:';
+      
+      const savingAsName = document.createElement('div');
+      savingAsName.className = 'path-value saving-as-name';
+      
+      filenameSection.appendChild(originalLabel);
+      filenameSection.appendChild(originalName);
+      filenameSection.appendChild(savingAsLabel);
+      filenameSection.appendChild(savingAsName);
+      
+      // From path section
+      const fromSection = document.createElement('div');
+      fromSection.className = 'path-section from-section';
+      
+      const fromLabel = document.createElement('div');
+      fromLabel.className = 'path-label';
+      fromLabel.textContent = 'FROM:';
+      
+      const fromPath = document.createElement('div');
+      fromPath.className = 'path-value from-path';
+      fromPath.textContent = '~/Documents/ComfyUI/output';
+      
+      fromSection.appendChild(fromLabel);
+      fromSection.appendChild(fromPath);
+      
+      // To path section
+      const toSection = document.createElement('div');
+      toSection.className = 'path-section to-section';
+      
+      const toLabel = document.createElement('div');
+      toLabel.className = 'path-label';
+      toLabel.textContent = 'TO:';
+      
+      const toPath = document.createElement('div');
+      toPath.className = 'path-value to-path';
+      toPath.textContent = '~/Documents/sorted';
+      
+      toSection.appendChild(toLabel);
+      toSection.appendChild(toPath);
+      
+      // Show instructions button
+      const instructionsSection = document.createElement('div');
+      instructionsSection.className = 'path-section instructions-section';
+      
+      const showInstructionsButton = document.createElement('button');
+      showInstructionsButton.id = 'showInfo';
+      showInstructionsButton.className = 'btn btn-info';
+      showInstructionsButton.textContent = 'Show Instructions';
+      
+      instructionsSection.appendChild(showInstructionsButton);
+      
+      // Add sections to overlay content
+      overlayContent.appendChild(filenameSection);
+      overlayContent.appendChild(fromSection);
+      overlayContent.appendChild(toSection);
+      overlayContent.appendChild(instructionsSection);
+      
+      pathOverlay.appendChild(overlayContent);
+      
+      // Header icons (download and refresh)
+      const headerIcons = document.createElement('div');
+      headerIcons.className = 'header-icons';
+      
+      const downloadButton = document.createElement('button');
+      downloadButton.className = 'icon-button save-icon';
+      downloadButton.title = 'Download';
+      downloadButton.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+          <polyline points="7 10 12 15 17 10"></polyline>
+          <line x1="12" y1="15" x2="12" y2="3"></line>
+        </svg>
+      `;
+      
+      const refreshButton = document.createElement('button');
+      refreshButton.className = 'icon-button refresh-icon';
+      refreshButton.title = 'Refresh';
+      refreshButton.innerHTML = '&#x21bb;';
+      
+      headerIcons.appendChild(downloadButton);
+      headerIcons.appendChild(refreshButton);
+      
+      // Add components to the header container
+      headerContainer.appendChild(fileHeader);
+      headerContainer.appendChild(pathOverlay);
+      headerContainer.appendChild(headerIcons);
+      
+      // Replace the existing header
+      existingHeaderContainer.parentNode.replaceChild(headerContainer, existingHeaderContainer);
+    }
+    
     // Add bottom controls container if it doesn't exist
     if (!document.querySelector('.bottom-controls')) {
       const bottomControls = document.createElement('div');
       bottomControls.className = 'bottom-controls';
       
-      // Add counter to the left
-      const counterContainer = document.createElement('div');
-      counterContainer.className = 'counter-container';
-      counterContainer.textContent = 'No images';
-      
-      // Add controls in the center
+      // Add prev, undo, next buttons
       const controls = document.createElement('div');
       controls.className = 'controls';
       
@@ -56,22 +195,26 @@ const uiManager = {
       prevButton.className = 'btn btn-secondary';
       prevButton.textContent = 'Previous';
       
-      const nextButton = document.createElement('button');
-      nextButton.className = 'btn btn-secondary';
-      nextButton.textContent = 'Next';
-      
-      // Add undo button
       const undoButton = document.createElement('button');
       undoButton.className = 'btn btn-undo';
       undoButton.textContent = 'Undo';
+      
+      const nextButton = document.createElement('button');
+      nextButton.className = 'btn btn-secondary';
+      nextButton.textContent = 'Next';
       
       controls.appendChild(prevButton);
       controls.appendChild(undoButton);
       controls.appendChild(nextButton);
       
+      // Add counter container
+      const counterContainer = document.createElement('div');
+      counterContainer.className = 'counter-container';
+      counterContainer.textContent = 'No images';
+      
       // Add bottom controls to container
-      bottomControls.appendChild(counterContainer);
       bottomControls.appendChild(controls);
+      bottomControls.appendChild(counterContainer);
       
       const container = document.querySelector('.container');
       container.appendChild(bottomControls);
@@ -165,6 +308,30 @@ const uiManager = {
     // Ensure elements exist before attaching handlers
     if (!this.elements.optionsButton) return;
     
+    // File header click to toggle path overlay
+    const fileHeader = document.querySelector('.file-header');
+    if (fileHeader) {
+      fileHeader.addEventListener('click', handlers.togglePathOverlay);
+    }
+    
+    // 'FROM' path click to edit
+    const fromPath = document.querySelector('.from-path');
+    if (fromPath) {
+      fromPath.addEventListener('click', (e) => {
+        e.stopPropagation();
+        handlers.editFromPath();
+      });
+    }
+    
+    // 'TO' path click to edit
+    const toPath = document.querySelector('.to-path');
+    if (toPath) {
+      toPath.addEventListener('click', (e) => {
+        e.stopPropagation();
+        handlers.editToPath();
+      });
+    }
+    
     // Options button toggle
     this.elements.optionsButton.addEventListener('click', () => {
       this.toggleOptionsDropdown();
@@ -221,32 +388,13 @@ const uiManager = {
       });
     }
     
-    // Navigation buttons
-    const prevButton = document.querySelector('.btn-secondary:first-child');
-    if (prevButton) {
-      prevButton.addEventListener('click', handlers.showPrevious);
-    }
-    
-    const nextButton = document.querySelector('.btn-secondary:last-of-type');
-    if (nextButton) {
-      nextButton.addEventListener('click', handlers.showNext);
-    }
-    
-    // Undo button
-    const undoButton = document.querySelector('.btn-undo');
-    if (undoButton) {
-      undoButton.addEventListener('click', handlers.undoLastAction);
-    }
-    
-    // Header buttons
-    const refreshIcon = document.querySelector('.refresh-icon');
-    if (refreshIcon) {
-      refreshIcon.addEventListener('click', handlers.refreshFiles);
-    }
-    
-    const saveIcon = document.querySelector('.save-icon');
-    if (saveIcon) {
-      saveIcon.addEventListener('click', handlers.downloadCurrentFile);
+    // Edit icon for custom filename
+    const editIcon = document.querySelector('.edit-icon');
+    if (editIcon) {
+      editIcon.addEventListener('click', (e) => {
+        e.stopPropagation();
+        handlers.openFilenameModal();
+      });
     }
   },
   
@@ -256,6 +404,76 @@ const uiManager = {
   toggleOptionsDropdown() {
     if (this.elements.optionsDropdown) {
       this.elements.optionsDropdown.classList.toggle('show');
+    }
+  },
+  
+  /**
+   * Toggle path overlay visibility
+   */
+  togglePathOverlay() {
+    if (this.elements.pathOverlay) {
+      const isVisible = this.elements.pathOverlay.style.display !== 'none';
+      this.elements.pathOverlay.style.display = isVisible ? 'none' : 'block';
+      
+      // Update caret direction
+      const caret = document.querySelector('.caret');
+      if (caret) {
+        caret.innerHTML = isVisible ? '&#9654;' : '&#9660;'; // Right vs Down
+      }
+    }
+  },
+  
+  /**
+   * Update the FROM and TO paths in the UI
+   * @param {string} fromPath - Path to read files from
+   * @param {string} toPath - Path to save files to
+   */
+  updatePathsDisplay(fromPath, toPath) {
+    const fromPathEl = document.querySelector('.from-path');
+    const toPathEl = document.querySelector('.to-path');
+    
+    if (fromPathEl && fromPath) {
+      fromPathEl.textContent = fromPath;
+    }
+    
+    if (toPathEl && toPath) {
+      toPathEl.textContent = toPath;
+    }
+  },
+  
+  /**
+   * Update the filename display in the header
+   * @param {string} originalName - Original filename
+   * @param {string} customName - Custom filename (if set)
+   */
+  updateFilenameDisplay(originalName, customName) {
+    // Update main filename display in header
+    const filenameEl = document.querySelector('.filename');
+    if (filenameEl) {
+      filenameEl.textContent = customName || originalName || 'No file selected';
+    }
+    
+    // Update edit icon visibility
+    const editIcon = document.querySelector('.edit-icon');
+    if (editIcon) {
+      editIcon.style.display = originalName ? 'inline-block' : 'none';
+    }
+    
+    // Update filename section in path overlay
+    const filenameSection = document.querySelector('.filename-section');
+    const originalNameEl = document.querySelector('.original-name');
+    const savingAsNameEl = document.querySelector('.saving-as-name');
+    
+    if (filenameSection && originalNameEl && savingAsNameEl) {
+      if (customName && originalName) {
+        // Show the filename section with both original and custom names
+        filenameSection.style.display = 'block';
+        originalNameEl.textContent = originalName;
+        savingAsNameEl.textContent = customName;
+      } else {
+        // Hide the filename section if there's no custom name
+        filenameSection.style.display = 'none';
+      }
     }
   },
   
@@ -347,43 +565,15 @@ const uiManager = {
       mediaContent = this.createVideoElement(file, apiUrl);
     }
     
-    // Add filename path container with semi-transparent background
-    const filenameContainer = document.createElement('div');
-    filenameContainer.className = 'filename-container overlay';
+    // Update main filename display
+    this.updateFilenameDisplay(file.name, customFilename);
     
-    // Extract path and actual filesystem path instead of browser URL
-    // Get the original path from file (which should be the filesystem path)
-    // This assumes 'file' contains the original path somewhere, either in name or as a property
-    const fsPath = file.originalPath || file.name; // Using file.name as fallback
-    
-    // Create path + bold filename
-    const filenamePath = document.createElement('div');
-    filenamePath.className = 'filename-path';
-    filenamePath.innerHTML = `<strong>${customFilename || file.name}</strong>`;
-    filenameContainer.appendChild(filenamePath);
-    
-    // Create 9-zone grid for taps
-    const tapZones = document.createElement('div');
-    tapZones.className = 'tap-zones';
-    
-    // Create zones according to config
-    window.appConfig.zoneConfig.forEach(zone => {
-      const zoneElement = document.createElement('div');
-      zoneElement.className = `tap-zone ${zone.className}`;
-      if (zone.action) {
-        zoneElement.dataset.action = zone.action;
-      }
-      tapZones.appendChild(zoneElement);
-    });
-    
-    // Create swipe instruction element
+    // Add swipe instruction element
     const swipeInstruction = document.createElement('div');
     swipeInstruction.className = 'swipe-instruction';
     
     // Assemble the media item
     item.appendChild(mediaContent);
-    item.appendChild(filenameContainer);
-    item.appendChild(tapZones);
     item.appendChild(swipeInstruction);
     
     return item;

--- a/public/styles.css
+++ b/public/styles.css
@@ -24,10 +24,10 @@ body {
 
 .header-container {
   display: flex;
-  justify-content: center;
-  align-items: center;
+  justify-content: space-between;
+  align-items: flex-start;
   position: relative;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 h1 {
@@ -37,8 +37,6 @@ h1 {
 }
 
 .header-icons {
-  position: absolute;
-  right: 0;
   display: flex;
   gap: 10px;
 }
@@ -71,11 +69,131 @@ h1 {
   height: 1.5rem;
 }
 
+/* New file header with caret */
+.file-header {
+  display: flex;
+  align-items: center;
+  background-color: #f8f8f8;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  cursor: pointer;
+  flex: 1;
+  margin-right: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  position: relative;
+}
+
+.file-header:hover {
+  background-color: #f0f0f0;
+}
+
+.caret {
+  margin-right: 8px;
+  font-size: 12px;
+  color: #666;
+  transition: transform 0.2s;
+}
+
+.filename {
+  flex: 1;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+  padding-right: 30px; /* Make room for edit icon */
+}
+
+.edit-icon {
+  position: absolute;
+  right: 10px;
+  font-size: 16px;
+  color: #888;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.edit-icon:hover {
+  color: #333;
+}
+
+/* Path overlay styling */
+.path-overlay {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background-color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+  margin-top: 2px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+}
+
+.overlay-content {
+  padding: 12px;
+}
+
+.path-section {
+  margin-bottom: 12px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 12px;
+}
+
+.path-section:last-child {
+  margin-bottom: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.path-label {
+  font-weight: bold;
+  font-size: 13px;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.path-value {
+  font-size: 14px;
+  word-wrap: break-word;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 3px;
+  transition: background-color 0.2s;
+}
+
+.path-value:hover {
+  background-color: #f0f0f0;
+}
+
+.filename-section {
+  display: none; /* Hidden by default, shown when custom filename is set */
+}
+
+.btn-info {
+  background-color: #6c757d;
+  color: white;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.btn-info:hover {
+  background-color: #5a6268;
+}
+
 /* New Options styling (top left) */
 .options-container {
   position: absolute;
   left: 0;
   z-index: 10;
+  display: none; /* Hide the options menu since we now use the path overlay */
 }
 
 .options-container .btn-options {
@@ -179,7 +297,7 @@ h1 {
 
 .media-item {
   background-color: #fff;
-  border-radius: 0 0 8px 8px;
+  border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   position: relative;
@@ -310,13 +428,15 @@ video.media-content::-webkit-media-controls-timeline:hover {
 .bottom-controls {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   margin: 10px 0;
+  flex-direction: column-reverse;
 }
 
 .counter-container {
   font-size: 0.9rem;
   color: #666;
+  margin-top: 5px;
 }
 
 .controls {
@@ -481,5 +601,14 @@ video.media-content::-webkit-media-controls-timeline:hover {
   .grid-explanation {
     max-width: 600px;
     margin: 15px auto;
+  }
+  
+  .bottom-controls {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  
+  .counter-container {
+    margin-top: 0;
   }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,147 +22,91 @@ body {
   height: 100vh;
 }
 
+/* Header Styles */
 .header-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
   position: relative;
   margin-bottom: 0.5rem;
 }
 
-h1 {
-  text-align: center;
-  font-size: 1.3rem;
-  flex: 1;
-}
-
-.header-icons {
-  display: flex;
-  gap: 10px;
-}
-
-.icon-button {
-  font-size: 1.44rem; /* 20% larger */
-  background: none;
-  border: none;
-  color: #666;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  transition: background-color 0.2s;
-}
-
-.icon-button:hover {
-  background-color: #e0e0e0;
-}
-
-.save-icon, .refresh-icon {
-  font-size: 1.5rem;
-}
-
-.save-icon svg {
-  width: 1.5rem;
-  height: 1.5rem;
-}
-
-/* New file header with caret */
+/* File Header (caret + filename) */
 .file-header {
   display: flex;
   align-items: center;
-  background-color: #f8f8f8;
-  padding: 8px 12px;
+  background-color: #fff;
+  padding: 0.5rem;
   border-radius: 4px;
-  border: 1px solid #ddd;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   cursor: pointer;
-  flex: 1;
-  margin-right: 10px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   position: relative;
-}
-
-.file-header:hover {
-  background-color: #f0f0f0;
+  z-index: 5;
 }
 
 .caret {
-  margin-right: 8px;
-  font-size: 12px;
-  color: #666;
+  font-size: 1rem;
+  margin-right: 0.5rem;
+  color: #777;
   transition: transform 0.2s;
 }
 
 .filename {
   flex: 1;
-  font-size: 14px;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   direction: rtl;
   text-align: left;
-  padding-right: 30px; /* Make room for edit icon */
 }
 
 .edit-icon {
-  position: absolute;
-  right: 10px;
-  font-size: 16px;
-  color: #888;
+  font-size: 0.9rem;
+  color: #777;
   cursor: pointer;
-  transition: color 0.2s;
+  margin-left: 0.5rem;
 }
 
 .edit-icon:hover {
   color: #333;
 }
 
-/* Path overlay styling */
+/* Path Overlay */
 .path-overlay {
   position: absolute;
   top: 100%;
   left: 0;
   right: 0;
   background-color: #fff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  z-index: 10;
-  margin-top: 2px;
-  border-radius: 4px;
-  border: 1px solid #ddd;
+  border-radius: 0 0 4px 4px;
+  padding: 0.75rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  z-index: 4;
+  margin-top: -1px;
 }
 
 .overlay-content {
-  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .path-section {
-  margin-bottom: 12px;
-  border-bottom: 1px solid #eee;
-  padding-bottom: 12px;
-}
-
-.path-section:last-child {
-  margin-bottom: 0;
-  border-bottom: none;
-  padding-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .path-label {
-  font-weight: bold;
-  font-size: 13px;
-  color: #555;
-  margin-bottom: 4px;
+  font-size: 0.8rem;
+  color: #777;
+  font-weight: 600;
 }
 
 .path-value {
-  font-size: 14px;
-  word-wrap: break-word;
+  font-size: 0.9rem;
+  color: #333;
+  word-break: break-all;
   cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 3px;
+  padding: 0.25rem;
+  border-radius: 2px;
   transition: background-color 0.2s;
 }
 
@@ -170,120 +114,10 @@ h1 {
   background-color: #f0f0f0;
 }
 
-.filename-section {
-  display: none; /* Hidden by default, shown when custom filename is set */
-}
-
-.btn-info {
-  background-color: #6c757d;
-  color: white;
-  padding: 6px 12px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 13px;
-}
-
-.btn-info:hover {
-  background-color: #5a6268;
-}
-
-/* New Options styling (top left) */
-.options-container {
-  position: absolute;
-  left: 0;
-  z-index: 10;
-  display: none; /* Hide the options menu since we now use the path overlay */
-}
-
-.options-container .btn-options {
-  background-color: #f5f5f5;
-  color: #777;
-  border: 1px solid #ddd;
-  padding: 6px 12px;
-  font-size: 0.85rem;
-  font-weight: normal;
-}
-
-.options-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background-color: white;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
-  padding: 0;
-  min-width: 180px;
-  z-index: 100;
-  display: none;
-  margin-top: 5px;
-}
-
-.options-dropdown.show {
-  display: block;
-}
-
-.options-dropdown ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.options-dropdown li {
-  padding: 10px 15px;
-  cursor: pointer;
-}
-
-.options-dropdown li:hover {
-  background-color: #f5f5f5;
-}
-
-/* Filename path container */
-.filename-container {
-  padding: 8px;
-  background-color: #f5f5f5;
-  border-radius: 8px 8px 0 0;
-  margin-bottom: 0;
-  border-bottom: 1px solid #ddd;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-/* Improved filename overlay style */
-.filename-container.overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  color: white;
-  border-radius: 0;
-  z-index: 10;
-  padding: 8px 12px;
-  border: none;
-}
-
-.filename-path {
-  font-size: 0.85rem;
-  color: #666;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Adjust filename text color for overlay */
-.overlay .filename-path {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.filename-path strong {
-  color: #333;
-  font-weight: 600;
-}
-
-.overlay .filename-path strong {
-  color: white;
-  font-weight: 600;
+.instructions-section {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
 }
 
 .media-list {
@@ -293,6 +127,7 @@ h1 {
   align-items: center;
   flex: 1;
   margin-bottom: 10px;
+  overflow: hidden;
 }
 
 .media-item {
@@ -425,18 +260,22 @@ video.media-content::-webkit-media-controls-timeline:hover {
   transition: all 0.3s ease; /* Faster transition */
 }
 
+/* Bottom Controls */
 .bottom-controls {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   margin: 10px 0;
-  flex-direction: column-reverse;
+}
+
+.utility-buttons {
+  display: flex;
+  gap: 10px;
 }
 
 .counter-container {
   font-size: 0.9rem;
   color: #666;
-  margin-top: 5px;
 }
 
 .controls {
@@ -464,6 +303,18 @@ video.media-content::-webkit-media-controls-timeline:hover {
   color: white;
 }
 
+.btn-info {
+  background-color: #17a2b8;
+  color: white;
+}
+
+.btn-utility {
+  background-color: #6c757d;
+  color: white;
+  padding: 6px 12px;
+  font-size: 0.9rem;
+}
+
 .btn:hover {
   opacity: 0.9;
 }
@@ -489,11 +340,11 @@ video.media-content::-webkit-media-controls-timeline:hover {
 
 .modal-content {
   background-color: #fefefe;
-  margin: 5% auto;
+  margin: 10% auto;
   padding: 20px;
   border-radius: 8px;
   width: 90%;
-  max-width: 600px;
+  max-width: 500px;
   max-height: 90vh;
   overflow-y: auto;
 }
@@ -601,14 +452,5 @@ video.media-content::-webkit-media-controls-timeline:hover {
   .grid-explanation {
     max-width: 600px;
     margin: 15px auto;
-  }
-  
-  .bottom-controls {
-    flex-direction: row;
-    justify-content: space-between;
-  }
-  
-  .counter-container {
-    margin-top: 0;
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,13 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// Set paths from URL when any request comes in
+app.use((req, res, next) => {
+  // Set paths based on URL parameters
+  config.setPathsFromUrl(req.url);
+  next();
+});
+
 // Create required directories
 fileOps.createRequiredDirectories();
 
@@ -36,6 +43,16 @@ app.use(express.static(path.join(__dirname, '..', 'public')));
 app.get('/', (req, res) => {
   const indexPath = path.join(__dirname, '..', 'public', 'index.html');
   res.sendFile(indexPath);
+});
+
+// New endpoint to get current paths
+app.get('/api/config/paths', (req, res) => {
+  res.json({
+    fromPath: config.OUTPUT_DIR,
+    toPath: config.LOCAL_COPY_DIR,
+    defaultFromPath: config.DEFAULT_OUTPUT_DIR,
+    defaultToPath: config.DEFAULT_SORTED_DIR
+  });
 });
 
 // Apply API routes

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,12 +1,94 @@
 const path = require('path');
 const moment = require('moment');
+const os = require('os');
+const url = require('url');
+
+// Get the home directory in a platform-agnostic way
+const homeDir = os.homedir();
+
+// Helper function to parse and validate paths
+function validatePath(pathStr) {
+  try {
+    // Convert ~ to home directory
+    if (pathStr.startsWith('~')) {
+      pathStr = path.join(homeDir, pathStr.slice(1));
+    }
+    
+    // Return resolved absolute path
+    return path.resolve(pathStr);
+  } catch (error) {
+    console.error(`Error validating path ${pathStr}:`, error);
+    return null;
+  }
+}
 
 // Configuration
 const config = {
-  // Directory Paths
-  OUTPUT_DIR: path.resolve(process.env.HOME, 'Documents/ComfyUI/output'),
-  LOCAL_COPY_DIR: path.resolve(process.env.HOME, 'Documents/ComfyUI/output/swipe-save'),
-  LOG_DIR: path.resolve(process.env.HOME, 'Documents/swipe-save/logs'),
+  // Default directory paths
+  DEFAULT_OUTPUT_DIR: path.resolve(homeDir, 'Documents/ComfyUI/output'),
+  DEFAULT_SORTED_DIR: path.resolve(homeDir, 'Documents/sorted'),
+  
+  // Current paths (can be modified at runtime)
+  _currentFromPath: null,
+  _currentToPath: null,
+  
+  // Get/Set the current from path
+  get OUTPUT_DIR() {
+    return this._currentFromPath || this.DEFAULT_OUTPUT_DIR;
+  },
+  
+  set OUTPUT_DIR(value) {
+    const validPath = validatePath(value);
+    if (validPath) {
+      this._currentFromPath = validPath;
+      console.log(`FROM path set to: ${validPath}`);
+    } else {
+      console.error(`Invalid FROM path: ${value}, using default`);
+      this._currentFromPath = this.DEFAULT_OUTPUT_DIR;
+    }
+  },
+  
+  // Get/Set the current to path
+  get LOCAL_COPY_DIR() {
+    return this._currentToPath || this.DEFAULT_SORTED_DIR;
+  },
+  
+  set LOCAL_COPY_DIR(value) {
+    const validPath = validatePath(value);
+    if (validPath) {
+      this._currentToPath = validPath;
+      console.log(`TO path set to: ${validPath}`);
+    } else {
+      console.error(`Invalid TO path: ${value}, using default`);
+      this._currentToPath = this.DEFAULT_SORTED_DIR;
+    }
+  },
+  
+  // Set paths from URL query parameters
+  setPathsFromUrl(reqUrl) {
+    if (!reqUrl) return;
+    
+    try {
+      // Parse the URL
+      const parsedUrl = url.parse(reqUrl, true);
+      const { fromPath, toPath } = parsedUrl.query;
+      
+      // Set FROM path if provided
+      if (fromPath) {
+        this.OUTPUT_DIR = fromPath;
+      }
+      
+      // Set TO path if provided
+      if (toPath) {
+        this.LOCAL_COPY_DIR = toPath;
+      }
+    } catch (error) {
+      console.error('Error parsing URL parameters:', error);
+    }
+  },
+  
+  // Directory for logs
+  LOG_DIR: path.resolve(homeDir, 'Documents/swipe-save/logs'),
   
   // Generate paths based on the base paths
   get DELETED_DIR() {
@@ -25,10 +107,14 @@ const config = {
   PORT: process.env.PORT || 8081
 };
 
+// Initialize with defaults
+config.OUTPUT_DIR = config.DEFAULT_OUTPUT_DIR;
+config.LOCAL_COPY_DIR = config.DEFAULT_SORTED_DIR;
+
 // Log the configuration paths
 console.log('Directory paths:');
-console.log(`OUTPUT_DIR: ${config.OUTPUT_DIR}`);
-console.log(`LOCAL_COPY_DIR: ${config.LOCAL_COPY_DIR}`);
+console.log(`OUTPUT_DIR (FROM): ${config.OUTPUT_DIR}`);
+console.log(`LOCAL_COPY_DIR (TO): ${config.LOCAL_COPY_DIR}`);
 console.log(`DELETED_DIR: ${config.DELETED_DIR}`);
 console.log(`LOG_DIR: ${config.LOG_DIR}`);
 console.log(`LOG_FILE: ${config.LOG_FILE}`);


### PR DESCRIPTION
## Custom Paths Feature

This PR adds the ability to set custom FROM and TO paths for sorting images:

### New Features:
- Set custom paths via URL parameters (`fromPath` and `toPath`)
- Default paths: FROM = ~/Documents/ComfyUI/output, TO = ~/Documents/sorted
- New UI with expandable header showing paths and allowing editing
- Filename display in header with edit button
- Removed previous options menu and added instructions button

### UI Changes:
- Clean header with filename and right-pointing caret
- Expandable overlay that shows:
  - Original/custom filename (when renamed)
  - FROM path (clickable to edit)
  - TO path (clickable to edit)
  - Instructions button

### Code Changes:
- Updated configuration to support custom paths
- Added new endpoints to get and set paths
- Redesigned UI components for better usability
- Updated styles for a cleaner, more functional interface
- Centralized download and refresh buttons

### Roadmap Items Completed:
- [x] Allow choosing which filepath to work from when sorting media
- [x] Allow choosing projects to save to

Next up: Verify TO and FROM paths already exist, or notify before creating

### Notes:
- Paths work on Linux/Mac by default
- Windows users can set custom paths via URL parameters
